### PR TITLE
make Vradar optional for Menu and Vlims optional in Display

### DIFF
--- a/execute_two.py
+++ b/execute_two.py
@@ -24,18 +24,18 @@ class make_MainDisplay(object):
 
 DirIn,field=parser.parse(sys.argv)
 
-Vradar = Variable(None)
+
 
 
 app = QtGui.QApplication(sys.argv)
 
-MainMenu = Menu(Vradar, DirIn, name="Menu") #initiate Vradar
+MainMenu = Menu(DirIn, name="Menu") #initiate Vradar
+Vradar = MainMenu.Vradar
 
 Vtilt = Variable(0)
 Vtilt2 = Variable(0)
-Vlims = Variable(None)
-plot1 = Display(Vradar, Variable(field), Vtilt, Vlims, name="Display1", parent=MainMenu)
-plot2 = Display(Vradar, Variable(field), Vtilt2, Vlims, name="Display2", parent=MainMenu)
+plot1 = Display(Vradar, Variable(field), Vtilt, name="Display1", parent=MainMenu)
+plot2 = Display(Vradar, Variable(field), Vtilt2, name="Display2", parent=MainMenu)
 
 app.exec_()
 

--- a/menu.py
+++ b/menu.py
@@ -10,11 +10,12 @@ import os
 from PyQt4 import QtGui, QtCore
 
 import common
+from core import Variable
 
 class Menu(QtGui.QMainWindow):
     '''Class to display the MainMenu'''
 
-    def __init__(self, Vradar, pathDir, name="Menu", parent=None):
+    def __init__(self, pathDir, Vradar=None, name="Menu", parent=None):
         '''Initialize the class to create the interface'''
         super(Menu, self).__init__(parent)
         self.name = name
@@ -29,7 +30,10 @@ class Menu(QtGui.QMainWindow):
         self.LaunchApp()      
                 
         # Show an "Open" dialog box and return the path to the selected file
-        self.showFileDialog()
+        # Just do that if Vradar was not given
+        if self.Vradar is None:
+            self.Vradar = Variable(None)
+            self.showFileDialog()
         
         # Connect the file advancement interface
         self.AddNextPrevMenu()

--- a/plot.py
+++ b/plot.py
@@ -17,6 +17,7 @@ from matplotlib.pyplot import cm
 
 import limits
 import common
+from core import Variable
 from limits import Ui_LimsDialog
 
 # Save image file type and DPI (resolution)
@@ -31,7 +32,7 @@ DPI = 100
 class Display(QtGui.QMainWindow):
     '''Class that plots a Radar structure using pyart.graph'''
 
-    def __init__(self, Vradar, Vfield, Vtilt, Vlims, airborne=False, rhi=False, name="Display", parent=None):
+    def __init__(self, Vradar, Vfield, Vtilt, Vlims=None, airborne=False, rhi=False, name="Display", parent=None):
         '''Initialize the class to create the interface'''
         super(Display, self).__init__(parent)
         self.parent = parent
@@ -47,8 +48,11 @@ class Display(QtGui.QMainWindow):
         QtCore.QObject.connect(Vfield,QtCore.SIGNAL("ValueChanged"),self.NewField)
         self.Vtilt = Vtilt
         QtCore.QObject.connect(Vtilt,QtCore.SIGNAL("ValueChanged"),self.NewTilt)
-        self.Vlims = Vlims
-        QtCore.QObject.connect(Vlims,QtCore.SIGNAL("ValueChanged"),self.NewLims)
+        if Vlims is None:
+            self.Vlims = Variable(None)
+        else:
+            self.Vlims = Vlims
+        QtCore.QObject.connect(self.Vlims,QtCore.SIGNAL("ValueChanged"),self.NewLims)
                 
         self.airborne = airborne
         self.rhi = rhi
@@ -60,7 +64,10 @@ class Display(QtGui.QMainWindow):
            
         self.limits, self.CMAP = limits.initialize_limits(self.Vfield.value, \
                                          airborne=self.airborne, rhi=self.rhi)
-            
+        
+        if self.Vlims.value is None:
+            self.Vlims.change(self.limits)
+        
         # Set the default range rings
         self.RngRingList = ["None", "10 km", "20 km", "30 km", "50 km", "100 km"]
         self.RngRing = False


### PR DESCRIPTION
Issue #17
Turn some V variable into optional arguments, those are initialized internaly.
In **execute_two.py** I accessed Vradar using `MainMenu.Vradar` instead creating function  `Main.Menu._getVradar()`. I don't think we need a get function here, do you agree?