### PR TITLE
Grid + Nomeclature change

### DIFF
--- a/artview/components/pick_value.py
+++ b/artview/components/pick_value.py
@@ -1,0 +1,83 @@
+"""
+pick_value.py
+
+Class to pick a value with the mouse.
+"""
+# Load the needed packages
+import numpy as np
+
+from PyQt4 import QtGui, QtCore
+
+from ..core import Variable, Component, common, VariableChoose
+
+
+class ValueClick(Component):
+
+#    @classmethod
+#    def guiStart(self, parent=None):
+#        args, independent = _RoiStart().startDisplay()
+#        return self(**args), independent
+
+    def __init__(self, display, name="ValueClick", parent=None):
+        '''
+        Initialize the class to pick value from display.
+
+        Parameters::
+        ----------
+        display - ARTView Display
+            Display instance to associate ValueClick. Must have following elements:
+                * getPlotAxis() - Matplotlib axis instance
+                * getStatusBar() - QtGui.QStatusBar
+                * getField() - string
+                * getUnits() - string
+                * getNearestPoints(xdata, ydata) - see
+                  :py:func:`~artview.components.GridDisplay.getNearestPoints`
+
+        [Optional]
+        name - string
+            Window name.
+        parent - PyQt instance
+            Parent instance to associate to ROI instance.
+            If None, then Qt owns, otherwise associated with parent PyQt
+            instance.
+        '''
+        super(ValueClick, self).__init__(name=name, parent=parent)
+        self.sharedVariables = {}
+
+        self.ax = display.getPlotAxis()
+        self.statusbar = display.getStatusBar()
+        self.fig = self.ax.get_figure()
+        self.getNearestPoints = display.getNearestPoints
+        self.getField = display.getField
+        self.getUnits = display.getUnits
+        self.connect()
+
+    def connect(self):
+        '''Connect the ValueClick instance'''
+        self.pickPointID = self.fig.canvas.mpl_connect(
+            'button_press_event', self.onPick)
+
+    def onPick(self, event):
+        '''Get value at the point selected by mouse click.'''
+        xdata = event.xdata  # get event x location
+        ydata = event.ydata  # get event y location
+        if (xdata is None) or (ydata is None):
+            msg = "Please choose point inside plot area"
+        else:
+            aux = self.getNearestPoints(xdata, ydata)
+            msg1 = ('x = %4.2f km,  y = %4.2f km,  z = %4.2f km,  ' %
+                    (aux[0][0]/1000., aux[1][0]/1000., aux[2][0]/1000.))
+            msg2 = '%s = %4.2f %s' % (self.getField(), aux[3][0],
+                                      self.getUnits())
+            msg = msg1 + msg2
+
+        self.statusbar.showMessage(msg)
+
+    def disconnect(self):
+        '''Disconnect the ValueClick instance'''
+        self.fig.canvas.mpl_disconnect(self.pickPointID)
+
+    def closeEvent(self, QCloseEvent):
+        '''Reimplementations to disconnect'''
+        self.disconnect()
+        super(ValueClick, self).closeEvent(QCloseEvent)

--- a/artview/components/plot_radar.py
+++ b/artview/components/plot_radar.py
@@ -562,12 +562,12 @@ class RadarDisplay(Component):
         -----
             If Vradar.value is None, returns None
         '''
-        from .tools import interior
+        from .tools import interior_radar
         radar = self.Vradar.value
         if radar is None:
             return (np.array([]),)*7
 
-        xy, idx = interior(path, radar, self.Vtilt.value)
+        xy, idx = interior_radar(path, radar, self.Vtilt.value)
         aux = (xy[:, 0], xy[:, 1], radar.azimuth['data'][idx[:, 0]],
                radar.range['data'][idx[:, 1]] / 1000.,
                radar.fields[self.Vfield.value]['data'][idx[:, 0], idx[:, 1]],
@@ -625,6 +625,7 @@ class RadarDisplay(Component):
 
         limits = self.Vlims.value
         cmap = self.Vcmap.value
+
         if self.plot_type == "radarAirborne":
             self.display = pyart.graph.RadarDisplay_Airborne(self.Vradar.value)
 
@@ -770,6 +771,7 @@ class RadarDisplay(Component):
             print "Changed Scan types, reinitializing"
             self._check_default_field()
             self._set_default_limits()
+            self._update_fig_ax()
 
     ########################
     # Image save methods #


### PR DESCRIPTION
I did something that may be I shouldn't: to match the updates in grid display I changes the nomenclature of other parts of the code.

* changed `Display` to `RadarDisplay` and `GridDisplay` 
* changed **tilt.py** by **level.py** as well as the names inside, and add a variable name Vlevel that may refer to Vtilt, VlevelZ, VlevelY or VlevelX
* in `RadarDisplay` changed scan_type to plot_type with names "radarPpi", "radarRhi" or "radarAirborne" to match "gridZ", "gridY" and "gridX" in  `GridDisplay` 
* add variable name Vcontainer that may refer to Vradar or Vgrid