### PR TITLE
Control

### DIFF
--- a/artview/__main__.py
+++ b/artview/__main__.py
@@ -9,10 +9,13 @@ sys.path.insert(0, path)
 
 import artview
 
+def main(argv):
+    script, DirIn, filename, field = artview.parser.parse(argv)
 
-script, DirIn, filename, field = artview.parser.parse(sys.argv)
+    if script:
+        artview.scripts.scripts[script](DirIn, filename, field)
+    else:
+        artview.run(DirIn, filename, field)
 
-if script:
-    artview.scripts.scripts[script](DirIn, filename, field)
-else:
-    artview.run(DirIn, filename, field)
+if __name__ == "__main__":
+    main(sys.argv)

--- a/artview/components/component_control.py
+++ b/artview/components/component_control.py
@@ -109,8 +109,8 @@ class ComponentsControl(core.Component):
         # Radio Buttons
         self.radioLayout = QtGui.QGridLayout()
         self.layout.addLayout(self.radioLayout, 2, 0)
-        self.radioLayout.addWidget(QtGui.QLabel("Conect"), 0, 1)
-        self.radioLayout.addWidget(QtGui.QLabel("Disconect"), 0, 2)
+        self.radioLayout.addWidget(QtGui.QLabel("Link"), 0, 1)
+        self.radioLayout.addWidget(QtGui.QLabel("Unlink"), 0, 2)
 
         self.radioBoxes = []
         for idx, var in enumerate(self.variables):
@@ -121,26 +121,26 @@ class ComponentsControl(core.Component):
         radioBox = QtGui.QButtonGroup()
         self.radioBoxes.append(radioBox)  # avoid garbage collector
 
-        conect = QtGui.QRadioButton()
-        disconect = QtGui.QRadioButton()
-        QtCore.QObject.connect(conect, QtCore.SIGNAL("clicked()"),
-                               partial(self.conectVar, var))
-        QtCore.QObject.connect(disconect, QtCore.SIGNAL("clicked()"),
-                               partial(self.disconectVar, var))
-        radioBox.addButton(conect)
-        radioBox.addButton(disconect)
+        link = QtGui.QRadioButton()
+        unlink = QtGui.QRadioButton()
+        QtCore.QObject.connect(link, QtCore.SIGNAL("clicked()"),
+                               partial(self.connectVar, var))
+        QtCore.QObject.connect(unlink, QtCore.SIGNAL("clicked()"),
+                               partial(self.disconnectVar, var))
+        radioBox.addButton(link)
+        radioBox.addButton(unlink)
 
         if getattr(self.comp0, var) is getattr(self.comp1, var):
-            conect.setChecked(True)
+            link.setChecked(True)
         else:
-            disconect.setChecked(True)
+            unlink.setChecked(True)
 
         if self.comp0 is self.comp1:
-            disconect.setDisabled(True)
+            unlink.setDisabled(True)
 
-        self.radioLayout.addWidget(QtGui.QLabel(var), idx+1, 0)
-        self.radioLayout.addWidget(conect, idx+1, 1)
-        self.radioLayout.addWidget(disconect, idx+1, 2)
+        self.radioLayout.addWidget(QtGui.QLabel(var[1::]), idx+1, 0)
+        self.radioLayout.addWidget(link, idx+1, 1)
+        self.radioLayout.addWidget(unlink, idx+1, 2)
 
     def _comp0Action(self, idx):
         '''Update Component 0'''
@@ -158,7 +158,7 @@ class ComponentsControl(core.Component):
         self.layout.removeItem(self.radioLayout)
         self._setRadioButtons()
 
-    def conectVar(self, var):
+    def connectVar(self, var):
         '''Assign variable in component 0 to component 1'''
         # Disconect old Variable
         self.comp1.disconnectSharedVariable(var)
@@ -171,7 +171,7 @@ class ComponentsControl(core.Component):
         print "connect var %s of %s from %s" % (
             var, self.comp1.name, self.comp0.name)
 
-    def disconectVar(self, var):
+    def disconnectVar(self, var):
         '''Turn variable in component 1 independente of component 0'''
         # Disconect old Variable
         self.comp1.disconnectSharedVariable(var)

--- a/artview/components/menu.py
+++ b/artview/components/menu.py
@@ -6,7 +6,7 @@ Class instance used to create menu for ARTView app.
 import numpy as np
 import pyart
 
-import os
+import os, sys
 from PyQt4 import QtGui, QtCore
 
 from ..core import Variable, Component, common
@@ -100,15 +100,22 @@ class Menu(Component):
         '''Launches a GUI interface.'''
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
-        # Create layout
-        self.central_widget = QtGui.QWidget()
-        self.setCentralWidget(self.central_widget)
-        self.centralLayout = QtGui.QVBoxLayout(self.central_widget)
-        self.centralLayout.setSpacing(8)
-        self.frames = {}
-
         # Create the menus
         self.CreateMenu()
+
+        # Create layout
+        if sys.version_info<(2,7,0):
+            self.central_widget = QtGui.QWidget()
+            self.setCentralWidget(self.central_widget)
+            self.centralLayout = QtGui.QVBoxLayout(self.central_widget)
+            self.centralLayout.setSpacing(8)
+            self.frames = {}
+            self.addLayoutMenu()
+        else:
+            self.mdiArea = QtGui.QMdiArea()
+            self.setCentralWidget(self.mdiArea)
+            self.mdiArea.setViewMode(1)
+            self.mdiArea.setTabsClosable(True)
 
     def showFileDialog(self):
         '''Open a dialog box to choose file.'''
@@ -127,13 +134,16 @@ class Menu(Component):
         Add a widget to central layout.
         This function is to be called both internal and external
         '''
-        frame = QtGui.QFrame()
-        frame.setFrameShape(QtGui.QFrame.Box)
-        layout = QtGui.QVBoxLayout(frame)
-        layout.addWidget(widget)
-        self.frames[widget.__repr__()] = frame
-        self.centralLayout.addWidget(frame)
-        self.addLayoutMenuItem(widget)
+        if sys.version_info<(2,7,0):
+            frame = QtGui.QFrame()
+            frame.setFrameShape(QtGui.QFrame.Box)
+            layout = QtGui.QVBoxLayout(frame)
+            layout.addWidget(widget)
+            self.frames[widget.__repr__()] = widget
+            self.centralLayout.addWidget(widget)
+            self.addLayoutMenuItem(widget)
+        else:
+            self.mdiArea.addSubWindow(widget)
 
     def removeLayoutWidget(self, widget):
         '''Remove widget from central layout.'''
@@ -163,7 +173,6 @@ class Menu(Component):
         self.addFileMenu()
         self.addAboutMenu()
         self.addFileAdvanceMenu()
-        self.addLayoutMenu()
         self.addComponentMenu()
 
     def addFileMenu(self):

--- a/artview/components/plot_radar.py
+++ b/artview/components/plot_radar.py
@@ -778,9 +778,10 @@ class RadarDisplay(Component):
     ########################
     def _quick_savefile(self, PTYPE=IMAGE_EXT):
         '''Save the current display via PyArt interface.'''
-        PNAME = self.display.generate_filename(
+        path = self.display.generate_filename(
             self.Vfield.value, self.Vtilt.value, ext=IMAGE_EXT)
-        print "Creating " + PNAME
+        self.canvas.print_figure(path, dpi=DPI)
+        self.statusbar.showMessage('Saved to %s' % path)
 
     def _savefile(self, PTYPE=IMAGE_EXT):
         '''Save the current display using PyQt dialog interface.'''
@@ -788,7 +789,7 @@ class RadarDisplay(Component):
             self.Vfield.value, self.Vtilt.value, ext=IMAGE_EXT)
         file_choices = "PNG (*.png)|*.png"
         path = unicode(QtGui.QFileDialog.getSaveFileName(
-            self, 'Save file', '', file_choices))
+            self, 'Save file', PBNAME, file_choices))
         if path:
             self.canvas.print_figure(path, dpi=DPI)
             self.statusbar.showMessage('Saved to %s' % path)

--- a/artview/core/core.py
+++ b/artview/core/core.py
@@ -9,6 +9,7 @@ Class instance to create Variables and establish change signals.
 
 # Load the needed packages
 from PyQt4 import QtGui, QtCore
+import sys
 
 # keet track of all components, this is not fundamental, but may be usefull
 # for some control utilities
@@ -166,7 +167,10 @@ class Component(QtGui.QMainWindow):
             Parent instance to associate to Component. If None, then Qt owns,
             otherwise associated with parent PyQt instance.
         '''
-        super(Component, self).__init__(parent=parent, flags=flags)
+        if sys.version_info<(2,7,0):
+            super(Component, self).__init__()
+        else:
+            super(Component, self).__init__(parent=parent, flags=flags)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
         self.name = name
         self.parent = parent

--- a/artview/scripts/standard.py
+++ b/artview/scripts/standard.py
@@ -71,9 +71,8 @@ def run(DirIn=os.getcwd(), filename=None, field=None):
     height = desktop_rect.height()
     width = desktop_rect.width()
 
-    menu_width = max(
-        MainMenu.menubar.sizeHint().width(), MainMenu.sizeHint().width())
-    menu_height = MainMenu.sizeHint().height()
+    menu_width = 300
+    menu_height = 180
 
     MainMenu.setGeometry(0, 0, menu_width, menu_height)
 

--- a/scripts/artview
+++ b/scripts/artview
@@ -1,0 +1,5 @@
+#! /usr/bin/env python
+
+import sys
+import artview.__main__
+artview.__main__.main(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ MINOR = 3
 MICRO = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
-SCRIPTS = glob.glob('scripts/*')
+SCRIPTS = glob.glob('scripts/*') + ['scripts/artview']
 
 
 # Return the git revision as a string


### PR DESCRIPTION
Before anyone else start addressing issue #53, here is somethings I already did:

* add tests for python 2.6, this should resolve issue #47 
* for python later than 2.7 change the menu layout to a tab layout, this is more intuitive
* some renaming in ComponentsControl, but not enough
* add script to run artview by just typing "artview"
* fix quick save file, although I don't understand what is the purpose as we already have savefile
* improve roi start (from the components menu) and add help button to roi