### PR TITLE
make instalation not mandatory

### DIFF
--- a/artview/__init__.py
+++ b/artview/__init__.py
@@ -38,10 +38,13 @@ if __ARTVIEW_SETUP__:
     _sys.stderr.write("Running from ARTview source directory.\n")
     del _sys
 else:
-
-    # versioning
-    from .version import git_revision as __git_revision__
-    from .version import version as __version__
+    try:
+        # versioning
+        from .version import git_revision as __git_revision__
+        from .version import version as __version__
+    except:
+        import warnings
+        warnings.warn("No ARTview Version!")
 
     import matplotlib
     matplotlib.use('Qt4Agg')

--- a/artview/parser.py
+++ b/artview/parser.py
@@ -12,13 +12,18 @@ import sys
 # I have read some posts about it and no one has a real solution.
 # http://stackoverflow.com/questions/16981921/relative-imports-in-python-3
 try:
-    import version
+    try:
+        import version
+    except:
+        from . import version
+
+    VERSION = version.version
 except:
-    from . import version
+    import warnings
+    warnings.warn("No ARTview Version!")
+    VERSION = 'no version'
 
 NAME = 'ARTview'
-VERSION = version.version
-
 
 def parse(argv):
     '''


### PR DESCRIPTION
Make artview run with no installation (i.e. no version file), for working around if installation fails or is not possible.