### PR TITLE
BUG: GateFilter plugin works on ndarray fields

### DIFF
--- a/artview/plugins/gatefilter.py
+++ b/artview/plugins/gatefilter.py
@@ -370,7 +370,7 @@ class GateFilter(Component):
         '''
         # Test radar
         if self.Vradar.value is None:
-            common.ShowWarning("Radar is None, can not perform filtering.")
+            common.ShowWarning("Radar is None, cannot perform filtering.")
             return
 
         # Retain the original masks

--- a/artview/plugins/gatefilter.py
+++ b/artview/plugins/gatefilter.py
@@ -329,8 +329,9 @@ class GateFilter(Component):
             return
         else:
             for field in self.Vradar.value.fields.keys():
-                self.Vradar.value.fields[field]['data'].mask = (
-                    self.Vgatefilter.value._gate_excluded)
+                self.Vradar.value.fields[field]['data'] = np.ma.array(
+                    self.Vradar.value.fields[field]['data'],
+                     mask=self.Vgatefilter.value._gate_excluded)
 
                 # **This section is a potential replacement for merging
                 # if problems are found in mask later **
@@ -351,8 +352,9 @@ class GateFilter(Component):
     def restoreRadar(self):
         '''Remove applied filters by restoring original mask'''
         for field in self.Vradar.value.fields.keys():
-            self.Vradar.value.fields[field]['data'].mask = (
-                self.original_masks[field])
+            self.Vradar.value.fields[field]['data'] = np.ma.array(
+                self.Vradar.value.fields[field]['data'],
+                    mask=self.original_masks[field])
         self.Vgatefilter.value._gate_excluded = self.original_masks[field]
         self.Vgatefilter.update(True)
 
@@ -374,8 +376,8 @@ class GateFilter(Component):
         # Retain the original masks
         self.original_masks = {}
         for field in self.Vradar.value.fields.keys():
-            self.original_masks[field] = (
-                self.Vradar.value.fields[field]['data'].mask)
+            self.original_masks[field] = np.ma.getmaskarray(
+                self.Vradar.value.fields[field]['data'])
             print(field)
 
         gatefilter = pyart.filters.GateFilter(self.Vradar.value,

--- a/artview/plugins/manual_filter.py
+++ b/artview/plugins/manual_filter.py
@@ -160,7 +160,7 @@ class ManualFilter(Component):
         mask_range = self.Vpoints.value.axes['range_index']['data'][:]
 
         data = np.ma.array(
-            self.Vradar.value.fields[self.Vfield.value]['data']
+            self.Vradar.value.fields[self.Vfield.value]['data'])
         data.mask[mask_ray, mask_range] = True
         self.Vradar.value.fields[self.Vfield.value]['data'] = data
 

--- a/artview/plugins/manual_filter.py
+++ b/artview/plugins/manual_filter.py
@@ -159,9 +159,8 @@ class ManualFilter(Component):
         mask_ray = self.Vpoints.value.axes['ray_index']['data'][:]
         mask_range = self.Vpoints.value.axes['range_index']['data'][:]
 
-        data = self.Vradar.value.fields[self.Vfield.value]['data']
-
-        np.ma.array(data)
+        data = np.ma.array(
+            self.Vradar.value.fields[self.Vfield.value]['data']
         data.mask[mask_ray, mask_range] = True
         self.Vradar.value.fields[self.Vfield.value]['data'] = data
 
@@ -177,9 +176,7 @@ class ManualFilter(Component):
         mask_range = self.Vpoints.value.axes['range_index']['data'][:]
 
         for field in self.Vradar.value.fields.keys():
-            data = self.Vradar.value.fields[field]['data']
-
-            np.ma.array(data)
+            data = np.ma.array(self.Vradar.value.fields[field]['data'])
             data.mask[mask_ray, mask_range] = True
             self.Vradar.value.fields[field]['data'] = data
 


### PR DESCRIPTION
The GateFilter plugin works on radar volumes which contain fields where the
data is stored as an ndarray not a MaskedArray object.

closes #121