### PR TITLE
add profiling

### DIFF
--- a/artview/__main__.py
+++ b/artview/__main__.py
@@ -7,15 +7,31 @@ path = os.path.join(path, '..')
 sys.path.insert(0, path)
 
 import artview
-
+try:
+    from version import profiling
+except:
+    profiling = False
 
 def main(argv):
+    if profiling:
+        import cProfile, pstats, StringIO
+        pr = cProfile.Profile()
+        pr.enable()
+
     script, DirIn, filename, field = artview.parser.parse(argv)
 
     if script:
         artview.scripts.scripts[script](DirIn, filename, field)
     else:
         artview.run(DirIn, filename, field)
+
+
+    if profiling:
+        pr.disable()
+        stream = open('profile.txt', 'w')
+        ps = pstats.Stats(pr, stream=stream).sort_stats('cumulative')
+        ps.print_stats('artview')
+        stream.close()
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ MAJOR = 1
 MINOR = 3
 MICRO = 3
 ISRELEASED = False
+ISPROFILING = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 SCRIPTS = glob.glob('scripts/*') + ['scripts/artview']
 
@@ -104,6 +105,7 @@ version = '%(version)s'
 full_version = '%(full_version)s'
 git_revision = '%(git_revision)s'
 release = %(isrelease)s
+profiling = %(isprofiling)s
 
 if not release:
     version = full_version

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,8 @@ if not release:
         a.write(cnt % {'version': VERSION,
                        'full_version': FULLVERSION,
                        'git_revision': GIT_REVISION,
-                       'isrelease': str(ISRELEASED)})
+                       'isrelease': str(ISRELEASED),
+                       'isprofiling': str(ISPROFILING)})
     finally:
         a.close()
 


### PR DESCRIPTION
add a new attribute the version file (that is not mapped in git), which when active will dump a profile to file profile.txt when artview is run from command line. This do not affect the normal user, since the standard is not profiling and one needs to change the **version.py** file manually to change that.

I pretend to let this on in my system and once in a while give a look in there, to find optimization points. 