### PR TITLE
select region: update points when tilt changes

### DIFF
--- a/artview/components/plot_grid.py
+++ b/artview/components/plot_grid.py
@@ -499,6 +499,7 @@ class GridDisplay(Component):
             display = pyart.graph.GridMapDisplay(self.Vgrid.value)
             self.VpyartDisplay.change(display)
             self._update_infolabel()
+            self.VpathInteriorFunc.update(True)
 
     def NewField(self, variable, strong):
         '''
@@ -521,6 +522,7 @@ class GridDisplay(Component):
         if strong:
             self._update_plot()
             self._update_infolabel()
+            self.VpathInteriorFunc.update(True)
 
     def NewLimits(self, variable, strong):
         '''
@@ -562,6 +564,7 @@ class GridDisplay(Component):
             self.title = self._get_default_title()
             self._update_plot()
             self._update_infolabel()
+            self.VpathInteriorFunc.update(True)
 
     def NewDisplay(self, variable, strong):
         '''

--- a/artview/components/plot_radar.py
+++ b/artview/components/plot_radar.py
@@ -506,6 +506,7 @@ class RadarDisplay(Component):
         if strong:
             self._update_display()
             self._update_infolabel()
+            self.VpathInteriorFunc.update(True)
 
     def NewField(self, variable, strong):
         '''
@@ -528,6 +529,7 @@ class RadarDisplay(Component):
         if strong:
             self._update_plot()
             self._update_infolabel()
+            self.VpathInteriorFunc.update(True)
 
     def NewLims(self, variable, strong):
         '''
@@ -581,6 +583,7 @@ class RadarDisplay(Component):
             self.title = self._get_default_title()
             self._update_plot()
             self._update_infolabel()
+            self.VpathInteriorFunc.update(True)
 
     def NewDisplay(self, variable, strong):
         '''

--- a/artview/components/select_region.py
+++ b/artview/components/select_region.py
@@ -100,7 +100,7 @@ class SelectRegion(Component):
             "VplotAxes": self.NewPlotAxes,
             "Vgatefilter": None,
             "Vradar": None,
-            "VpathInteriorFunc": None,
+            "VpathInteriorFunc": self.NewPathInteriorFunc,
             "Vfield": None,
             "Vpoints": None}
         # Connect the components
@@ -359,3 +359,7 @@ class SelectRegion(Component):
                 for line in poly:
                     self.VplotAxes.value.add_line(line)
                 self.fig.canvas.draw()
+
+    def NewPathInteriorFunc(self, variable, strong):
+        if strong:
+            self.update_points()


### PR DESCRIPTION
addresses old complain that points from select region get outdate by changing the sweep.

important discovery: function exported using shared variable can be update (i.e. call the `update` method) to reflect a change in the expected function results. This is really good.

Not sure if this is a strong or a weak update though, for now I set it to strong. 