### PR TITLE
update use of PyQt as matplotlib backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ to the list.
 ## Dependencies
 [Py-ART](https://github.com/ARM-DOE/pyart) >= 1.6
 
-[matplotlib](http://matplotlib.org) >= 1.1.0
+[matplotlib](http://matplotlib.org) >= 2.0.0
 
 [Basemap](http://matplotlib.org/basemap) >= 0.99
 

--- a/artview/__init__.py
+++ b/artview/__init__.py
@@ -51,10 +51,8 @@ else:
     import matplotlib
     if core.QtCore.__name__ == 'PyQt4.QtCore':
         matplotlib.use('Qt4Agg')
-        matplotlib.rcParams['backend.qt4'] = 'PyQt4'
     elif core.QtCore.__name__ == 'PyQt5.QtCore':
         matplotlib.use('Qt5Agg')
-        matplotlib.rcParams['backend.qt5'] = 'PyQt5'
 
     from . import components
     from . import plugins

--- a/artview/components/cmap.py
+++ b/artview/components/cmap.py
@@ -8,9 +8,12 @@ from ..core import QtWidgets, QtGui, QtCore
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
-from matplotlib.backends import pylab_setup
-FigureCanvasQTAgg = pylab_setup()[0].FigureCanvasQTAgg
-#from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg
+from matplotlib.backends.qt_compat import is_pyqt5
+if is_pyqt5():
+    from matplotlib.backends.backend_qt5agg import FigureCanvas
+else:
+    from matplotlib.backends.backend_qt4agg import FigureCanvas
+
 from matplotlib import colors
 
 import pyart

--- a/artview/components/correlation.py
+++ b/artview/components/correlation.py
@@ -9,13 +9,14 @@ import scipy
 import os
 import pyart
 
-from matplotlib.backends import pylab_setup
-backend = pylab_setup()[0]
-FigureCanvasQTAgg = backend.FigureCanvasQTAgg
-NavigationToolbar = backend.NavigationToolbar2QT
-#from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg
-#from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as \
-#    NavigationToolbar
+from matplotlib.backends.qt_compat import is_pyqt5
+if is_pyqt5():
+    from matplotlib.backends.backend_qt5agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+else:
+    from matplotlib.backends.backend_qt4agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+
 from matplotlib.figure import Figure
 from matplotlib.colors import Normalize as mlabNormalize
 from matplotlib.colorbar import ColorbarBase as mlabColorbarBase

--- a/artview/components/plot_grid.py
+++ b/artview/components/plot_grid.py
@@ -8,13 +8,14 @@ import numpy as np
 import os
 import pyart
 
-from matplotlib.backends import pylab_setup
-backend = pylab_setup()[0]
-FigureCanvasQTAgg = backend.FigureCanvasQTAgg
-NavigationToolbar = backend.NavigationToolbar2QT
-#from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg
-#from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as \
-#    NavigationToolbar
+from matplotlib.backends.qt_compat import is_pyqt5
+if is_pyqt5():
+    from matplotlib.backends.backend_qt5agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+else:
+    from matplotlib.backends.backend_qt4agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+
 from matplotlib.figure import Figure
 from matplotlib.colors import Normalize as mlabNormalize
 from matplotlib.colorbar import ColorbarBase as mlabColorbarBase

--- a/artview/components/plot_grid_legacy.py
+++ b/artview/components/plot_grid_legacy.py
@@ -8,13 +8,14 @@ import numpy as np
 import os
 import pyart
 
-from matplotlib.backends import pylab_setup
-backend = pylab_setup()[0]
-FigureCanvasQTAgg = backend.FigureCanvasQTAgg
-NavigationToolbar = backend.NavigationToolbar2QT
-#from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg
-#from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as \
-#    NavigationToolbar
+from matplotlib.backends.qt_compat import is_pyqt5
+if is_pyqt5():
+    from matplotlib.backends.backend_qt5agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+else:
+    from matplotlib.backends.backend_qt4agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+
 from matplotlib.figure import Figure
 from matplotlib.colors import Normalize as mlabNormalize
 from matplotlib.colorbar import ColorbarBase as mlabColorbarBase

--- a/artview/components/plot_points.py
+++ b/artview/components/plot_points.py
@@ -8,13 +8,14 @@ import numpy as np
 import os
 import pyart
 
-from matplotlib.backends import pylab_setup
-backend = pylab_setup()[0]
-FigureCanvasQTAgg = backend.FigureCanvasQTAgg
-NavigationToolbar = backend.NavigationToolbar2QT
-#from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg
-#from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as \
-#    NavigationToolbar
+from matplotlib.backends.qt_compat import is_pyqt5
+if is_pyqt5():
+    from matplotlib.backends.backend_qt5agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+else:
+    from matplotlib.backends.backend_qt4agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+
 from matplotlib.figure import Figure
 from matplotlib.colors import Normalize as mlabNormalize
 from matplotlib.colorbar import ColorbarBase as mlabColorbarBase

--- a/artview/components/plot_radar.py
+++ b/artview/components/plot_radar.py
@@ -12,7 +12,7 @@ import pyart
 from matplotlib.backends.qt_compat import is_pyqt5
 if is_pyqt5():
     from matplotlib.backends.backend_qt5agg import (
-        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar, FigureCanvasQTAgg)
 else:
     from matplotlib.backends.backend_qt4agg import (
         FigureCanvas, NavigationToolbar2QT as NavigationToolbar)

--- a/artview/components/plot_radar.py
+++ b/artview/components/plot_radar.py
@@ -9,13 +9,14 @@ import numpy as np
 import os
 import pyart
 
-from matplotlib.backends import pylab_setup
-backend = pylab_setup()[0]
-FigureCanvasQTAgg = backend.FigureCanvasQTAgg
-NavigationToolbar = backend.NavigationToolbar2QT
-#from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg
-#from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as \
-#    NavigationToolbar
+from matplotlib.backends.qt_compat import is_pyqt5
+if is_pyqt5():
+    from matplotlib.backends.backend_qt5agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+else:
+    from matplotlib.backends.backend_qt4agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+
 from matplotlib.figure import Figure
 from matplotlib.colors import Normalize as mlabNormalize
 from matplotlib.colorbar import ColorbarBase as mlabColorbarBase

--- a/artview/components/plot_simple.py
+++ b/artview/components/plot_simple.py
@@ -8,13 +8,15 @@ import numpy as np
 import os
 import pyart
 
-from matplotlib.backends import pylab_setup
-backend = pylab_setup()[0]
-FigureCanvasQTAgg = backend.FigureCanvasQTAgg
-NavigationToolbar = backend.NavigationToolbar2QT
-#from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg
-#from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as \
-#    NavigationToolbar
+
+from matplotlib.backends.qt_compat import is_pyqt5
+if is_pyqt5():
+    from matplotlib.backends.backend_qt5agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+else:
+    from matplotlib.backends.backend_qt4agg import (
+        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+
 from matplotlib.figure import Figure
 from matplotlib.colors import Normalize as mlabNormalize
 from matplotlib.colorbar import ColorbarBase as mlabColorbarBase

--- a/artview/core/core.py
+++ b/artview/core/core.py
@@ -7,11 +7,7 @@ Class instance to create Variables and establish change signals.
 
 # Load the needed packages
 # this should the only place with reference to PyQt4
-try:
-    from PyQt4 import QtGui, QtCore
-    QtWidgets = QtGui
-except:
-    from PyQt5 import QtWidgets, QtCore, QtGui
+from matplotlib.backends.qt_compat import QtCore, QtWidgets, QtGui
 import sys
 
 # lets add some magic for the documentation


### PR DESCRIPTION
Attempt to solve Issue #216 

Notice that PyQt4 is no longer is the standard backend, but what ever matplotlib imports: in order to force matplotlib the use of a specific Qt binding, either import that binding first, or set the QT_API environment variable.

I have not tested this, as my computer is not corrected configured. Please test it before accepting the PR.

It would also be nice to test in an older matplotlib version, as I could not find any documentation prior to 2.0. I changed the minimum requirement in README just in case. 
